### PR TITLE
Provider with filter

### DIFF
--- a/Elmah.Io.Extensions.Logging/ElmahIoLogger.cs
+++ b/Elmah.Io.Extensions.Logging/ElmahIoLogger.cs
@@ -11,11 +11,11 @@ namespace Elmah.Io.Extensions.Logging
         private readonly LogLevel _level;
 
         public ElmahIoLogger(string apiKey, Guid logId, LogLevel level)
-         {
-             _logId = logId;
-             _level = level;
-             _elmahioApi = ElmahioAPI.Create(apiKey);
-         }
+        {
+            _logId = logId;
+            _level = level;
+            _elmahioApi = ElmahioAPI.Create(apiKey);
+        }
  
          public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
          {

--- a/Elmah.Io.Extensions.Logging/ElmahIoLogger.cs
+++ b/Elmah.Io.Extensions.Logging/ElmahIoLogger.cs
@@ -6,12 +6,14 @@ namespace Elmah.Io.Extensions.Logging
 {
     public class ElmahIoLogger : ILogger
      {
-         private readonly IElmahioAPI _elmahioApi;
-         private readonly Guid _logId;
- 
-         public ElmahIoLogger(string apiKey, Guid logId)
+        private readonly IElmahioAPI _elmahioApi;
+        private readonly Guid _logId;
+        private readonly LogLevel _level;
+
+        public ElmahIoLogger(string apiKey, Guid logId, LogLevel level)
          {
              _logId = logId;
+             _level = level;
              _elmahioApi = ElmahioAPI.Create(apiKey);
          }
  
@@ -29,7 +31,7 @@ namespace Elmah.Io.Extensions.Logging
  
          public bool IsEnabled(LogLevel logLevel)
          {
-             return logLevel != LogLevel.None;
+            return logLevel > _level;
          }
  
          public IDisposable BeginScope<TState>(TState state)

--- a/Elmah.Io.Extensions.Logging/ElmahIoLoggerFactoryExtensions.cs
+++ b/Elmah.Io.Extensions.Logging/ElmahIoLoggerFactoryExtensions.cs
@@ -10,5 +10,11 @@ namespace Elmah.Io.Extensions.Logging
             factory.AddProvider(new ElmahIoLoggerProvider(apiKey, logId));
             return factory;
         }
+
+        public static ILoggerFactory AddElmahIoWithFilter(this ILoggerFactory factory, string apiKey, Guid logId, FilterLoggerSettings filter)
+        {
+            factory.AddProvider(new ElmahIoLoggerProvider(apiKey, logId, filter));
+            return factory;
+        }
     }
 }

--- a/Elmah.Io.Extensions.Logging/ElmahIoLoggerFactoryExtensions.cs
+++ b/Elmah.Io.Extensions.Logging/ElmahIoLoggerFactoryExtensions.cs
@@ -11,7 +11,7 @@ namespace Elmah.Io.Extensions.Logging
             return factory;
         }
 
-        public static ILoggerFactory AddElmahIoWithFilter(this ILoggerFactory factory, string apiKey, Guid logId, FilterLoggerSettings filter)
+        public static ILoggerFactory AddElmahIo(this ILoggerFactory factory, string apiKey, Guid logId, FilterLoggerSettings filter)
         {
             factory.AddProvider(new ElmahIoLoggerProvider(apiKey, logId, filter));
             return factory;

--- a/Elmah.Io.Extensions.Logging/ElmahIoLoggerProvider.cs
+++ b/Elmah.Io.Extensions.Logging/ElmahIoLoggerProvider.cs
@@ -26,7 +26,7 @@ namespace Elmah.Io.Extensions.Logging
 
         private LogLevel FindLevel(string categoryName)
         {
-            var def = LogLevel.Trace;
+            var def = LogLevel.Debug;
             foreach (var s in _filter.Switches)
             {
                 if (categoryName.Contains(s.Key))

--- a/Elmah.Io.Extensions.Logging/ElmahIoLoggerProvider.cs
+++ b/Elmah.Io.Extensions.Logging/ElmahIoLoggerProvider.cs
@@ -18,7 +18,7 @@ namespace Elmah.Io.Extensions.Logging
             {
                 filter = new FilterLoggerSettings
                 {
-                    {"*", LogLevel.Trace}
+                    {"*", LogLevel.Warning}
                 };
             }
             _filter = filter;
@@ -26,7 +26,7 @@ namespace Elmah.Io.Extensions.Logging
 
         private LogLevel FindLevel(string categoryName)
         {
-            var def = LogLevel.Debug;
+            var def = LogLevel.Warning;
             foreach (var s in _filter.Switches)
             {
                 if (categoryName.Contains(s.Key))

--- a/Elmah.Io.Extensions.Logging/ElmahIoLoggerProvider.cs
+++ b/Elmah.Io.Extensions.Logging/ElmahIoLoggerProvider.cs
@@ -7,16 +7,42 @@ namespace Elmah.Io.Extensions.Logging
     {
         private readonly string _apiKey;
         private readonly Guid _logId;
+        private readonly FilterLoggerSettings _filter;
 
-        public ElmahIoLoggerProvider(string apiKey, Guid logId)
+        public ElmahIoLoggerProvider(string apiKey, Guid logId, FilterLoggerSettings filter = null)
         {
             _apiKey = apiKey;
             _logId = logId;
+
+            if (filter == null)
+            {
+                filter = new FilterLoggerSettings
+                {
+                    {"*", LogLevel.Trace}
+                };
+            }
+            _filter = filter;
+        }
+
+        private LogLevel FindLevel(string categoryName)
+        {
+            var def = LogLevel.Trace;
+            foreach (var s in _filter.Switches)
+            {
+                if (categoryName.Contains(s.Key))
+                    return s.Value;
+
+                if (s.Key == "*")
+                    def = s.Value;
+            }
+
+            return def;
         }
 
         public ILogger CreateLogger(string name)
         {
-            return new ElmahIoLogger(_apiKey, _logId);
+            var lvl = FindLevel(name);
+            return new ElmahIoLogger(_apiKey, _logId, lvl);
         }
 
         public void Dispose()

--- a/Elmah.Io.Extensions.Logging/ElmahIoLoggerProvider.cs
+++ b/Elmah.Io.Extensions.Logging/ElmahIoLoggerProvider.cs
@@ -41,8 +41,7 @@ namespace Elmah.Io.Extensions.Logging
 
         public ILogger CreateLogger(string name)
         {
-            var lvl = FindLevel(name);
-            return new ElmahIoLogger(_apiKey, _logId, lvl);
+            return new ElmahIoLogger(_apiKey, _logId, FindLevel(name));
         }
 
         public void Dispose()

--- a/Elmah.Io.Extensions.Logging/project.json
+++ b/Elmah.Io.Extensions.Logging/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-*",
+  "version": "1.0.0-venntage-*",
   "description": "An elmah.io provider for Microsoft.Extensions.Logging",
   "authors": [ "elmah.io" ],
   "packOptions": {

--- a/Elmah.Io.Extensions.Logging/project.json
+++ b/Elmah.Io.Extensions.Logging/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2-*",
+  "version": "1.0.0-*",
   "description": "An elmah.io provider for Microsoft.Extensions.Logging",
   "authors": [ "elmah.io" ],
   "packOptions": {

--- a/Elmah.Io.Extensions.Logging/project.json
+++ b/Elmah.Io.Extensions.Logging/project.json
@@ -1,5 +1,5 @@
-﻿{
-  "version": "1.0.0-*",
+{
+  "version": "1.0.2-*",
   "description": "An elmah.io provider for Microsoft.Extensions.Logging",
   "authors": [ "elmah.io" ],
   "packOptions": {
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "Elmah.Io.Client": "3.0.0-pre-21",
-    "Microsoft.Extensions.Logging.Abstractions": "1.0.0"
+    "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
+    "Microsoft.Extensions.Logging.Filter": "1.0.0"
   },
 
   "frameworks": {

--- a/Elmah.Io.Extensions.Logging/project.json
+++ b/Elmah.Io.Extensions.Logging/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-venntage-*",
+  "version": "1.0.0-*",
   "description": "An elmah.io provider for Microsoft.Extensions.Logging",
   "authors": [ "elmah.io" ],
   "packOptions": {


### PR DESCRIPTION
This PR adds an option to provide filters for the loggerfactory extension, using FilterSettings in Microsoft.Extensions.Logging.Filter. 

This does not fix elmahio/Elmah.Io.Client#1 but will atleast provde a possibility to filter away entity framework logs.
