### PR TITLE
Feature/formdata logging extensions

### DIFF
--- a/src/Elmah.Io.AspNetCore.ExtensionsLogging/DisableElmahIoFormLoggingMetadata.cs
+++ b/src/Elmah.Io.AspNetCore.ExtensionsLogging/DisableElmahIoFormLoggingMetadata.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
+namespace Microsoft.AspNetCore.Builder
+#pragma warning restore IDE0130 // Namespace does not match folder structure
+{
+    public class DisableElmahIoFormLoggingMetadata : IDisableElmahIoFormLoggingMetadata
+    {
+        public bool IncludeFormContentType { get; } = false;
+        public DisableElmahIoFormLoggingMetadata(bool includeFormContentType = false)
+        {
+            IncludeFormContentType = includeFormContentType;
+        }
+    }
+}

--- a/src/Elmah.Io.AspNetCore.ExtensionsLogging/Elmah.Io.AspNetCore.ExtensionsLogging.csproj
+++ b/src/Elmah.Io.AspNetCore.ExtensionsLogging/Elmah.Io.AspNetCore.ExtensionsLogging.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.9" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.32" />
   </ItemGroup>
 

--- a/src/Elmah.Io.AspNetCore.ExtensionsLogging/ElmahIoAspNetCoreExtensionsLoggingExtensions.cs
+++ b/src/Elmah.Io.AspNetCore.ExtensionsLogging/ElmahIoAspNetCoreExtensionsLoggingExtensions.cs
@@ -18,5 +18,31 @@ namespace Microsoft.AspNetCore.Builder
         {
             return app.UseMiddleware<ElmahIoExtensionsLoggingMiddleware>();
         }
+
+#if NET8_0_OR_GREATER
+        /// <summary>
+        /// Disables logging of form values from the HTTP context in the
+        /// Elmah.Io.AspNetCore.ExtensionsLogging middleware. This is useful if you don't want form
+        /// data to be included in the logs (i.e. for sensitive form data or files).
+        /// </summary>
+        public static TBuilder DisableElmahIoFormLogging<TBuilder>(this TBuilder builder, bool includeFormContentType = false) where TBuilder : IEndpointConventionBuilder
+        {
+            builder.WithMetadata(new DisableElmahIoFormLoggingMetadata(includeFormContentType));
+            return builder;
+        }
+#endif
+
+#if NET8_0_OR_GREATER
+        /// <summary>
+        /// Enables logging of multipart form data from the HTTP context. By default, multipart form data
+        /// is not logged because it can result in exceptions when the application also tries to consume 
+        /// the request body as a stream without request buffering being enabled.
+        /// </summary>
+        public static TBuilder OptIntoElmahIoMultipartBodyLogging<TBuilder>(this TBuilder builder) where TBuilder : IEndpointConventionBuilder
+        {
+            builder.WithMetadata(new OptIntoElmahIoMultipartBodyLoggingMetadata());
+            return builder;
+        }
+#endif
     }
 }

--- a/src/Elmah.Io.AspNetCore.ExtensionsLogging/ElmahIoExtensionsLoggingMiddleware.cs.cs
+++ b/src/Elmah.Io.AspNetCore.ExtensionsLogging/ElmahIoExtensionsLoggingMiddleware.cs.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
@@ -32,7 +34,7 @@ namespace Elmah.Io.AspNetCore.ExtensionsLogging
                 { "user", context.User?.Identity?.Name },
                 { "servervariables", ServerVariables(context) },
                 { "cookies", Cookies(context) },
-                { "form", Form(context) },
+                { "form", await Form(context) },
                 { "querystring", QueryString(context) },
             };
             using (_logger.BeginScope(loggerState))
@@ -46,14 +48,36 @@ namespace Elmah.Io.AspNetCore.ExtensionsLogging
             return context.Request?.Query?.Keys.ToDictionary(k => k, k => context.Request.Query[k].ToString());
         }
 
-        private static Dictionary<string, string> Form(HttpContext context)
+        private async Task<Dictionary<string, string>> Form(HttpContext context)
         {
             try
             {
-                if (context.Request == null || !context.Request.HasFormContentType) return [];
-                if (context.Request?.ContentType?.StartsWith("multipart/", StringComparison.OrdinalIgnoreCase) == true) return [];
+                if (context.Request == null || !context.Request.HasFormContentType) return []; // internal logic for HasFormContentType: Content-Type header with "application/x-www-form-urlencoded" or "multipart/form-data"
+#if NET8_0_OR_GREATER
+                var endpoint = context.Features.Get<IEndpointFeature>()?.Endpoint;
+                var disableFormLoggingMetadata = endpoint?.Metadata.GetMetadata<IDisableElmahIoFormLoggingMetadata>();
+                if (disableFormLoggingMetadata is not null)
+                {
+                    if (disableFormLoggingMetadata.IncludeFormContentType)
+                    {
+                        return new Dictionary<string, string> { { "ContentType", context.Request.ContentType ?? "" } };
+                    }
+                    return [];
+                }
 
-                return context.Request?.Form?.Keys.ToDictionary(k => k, k => context.Request.Form[k].ToString());
+                if (context.Request.ContentType?.StartsWith("multipart/", StringComparison.OrdinalIgnoreCase) == true)
+                {
+                    var optIntoMultipartLoggingMetadata = endpoint?.Metadata.GetMetadata<IOptIntoElmahIoMultipartBodyLoggingMetadata>();
+                    if (optIntoMultipartLoggingMetadata is null)
+                    {
+                        return [];
+                    }
+                }
+#else
+                if (context.Request?.ContentType?.StartsWith("multipart/", StringComparison.OrdinalIgnoreCase) == true) return [];
+#endif
+                var formData = await context.Request.ReadFormAsync(); // recommended over accessing Request.Form: https://learn.microsoft.com/en-us/aspnet/core/fundamentals/best-practices?view=aspnetcore-6.0#prefer-readformasync-over-requestform
+                return formData?.Keys.ToDictionary(k => k, k => context.Request.Form[k].ToString()) ?? [];
             }
             catch (Exception)
             {
@@ -61,7 +85,7 @@ namespace Elmah.Io.AspNetCore.ExtensionsLogging
                 // - InvalidOperationException: Request not a form POST or similar
                 // - InvalidDataException: Form body without a content-type or similar
                 // - ConnectionResetException: More than 100 active connections or similar
-                // - System.IO.IOException: Unexpected end of stream
+                // - System.IO.IOException: Unexpected end of stream because the client disconnected or the stream has already been read elsewhere.
 
                 // In case of an exception return an empty dictionary since we still want the middleware to run
                 return [];

--- a/src/Elmah.Io.AspNetCore.ExtensionsLogging/ElmahIoExtensionsLoggingMiddleware.cs.cs
+++ b/src/Elmah.Io.AspNetCore.ExtensionsLogging/ElmahIoExtensionsLoggingMiddleware.cs.cs
@@ -77,7 +77,7 @@ namespace Elmah.Io.AspNetCore.ExtensionsLogging
                 if (context.Request?.ContentType?.StartsWith("multipart/", StringComparison.OrdinalIgnoreCase) == true) return [];
 #endif
                 var formData = await context.Request.ReadFormAsync(); // recommended over accessing Request.Form: https://learn.microsoft.com/en-us/aspnet/core/fundamentals/best-practices?view=aspnetcore-6.0#prefer-readformasync-over-requestform
-                return formData?.Keys.ToDictionary(k => k, k => context.Request.Form[k].ToString()) ?? [];
+                return formData?.ToDictionary(k => k.Key, v => v.Value.ToString()) ?? [];
             }
             catch (Exception)
             {

--- a/src/Elmah.Io.AspNetCore.ExtensionsLogging/IDisableElmahIoFormLoggingMetadata.cs
+++ b/src/Elmah.Io.AspNetCore.ExtensionsLogging/IDisableElmahIoFormLoggingMetadata.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
+namespace Microsoft.AspNetCore.Builder
+#pragma warning restore IDE0130 // Namespace does not match folder structure
+{
+    public interface IDisableElmahIoFormLoggingMetadata
+    {
+        bool IncludeFormContentType { get; }
+    }
+}

--- a/src/Elmah.Io.AspNetCore.ExtensionsLogging/IOptIntoElmahIoMultipartBodyLoggingMetadata.cs
+++ b/src/Elmah.Io.AspNetCore.ExtensionsLogging/IOptIntoElmahIoMultipartBodyLoggingMetadata.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
+namespace Microsoft.AspNetCore.Builder
+#pragma warning restore IDE0130 // Namespace does not match folder structure
+{
+    public interface IOptIntoElmahIoMultipartBodyLoggingMetadata { }
+}

--- a/src/Elmah.Io.AspNetCore.ExtensionsLogging/OptIntoElmahIoMultipartBodyLoggingMetadata.cs
+++ b/src/Elmah.Io.AspNetCore.ExtensionsLogging/OptIntoElmahIoMultipartBodyLoggingMetadata.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
+namespace Microsoft.AspNetCore.Builder
+#pragma warning restore IDE0130 // Namespace does not match folder structure
+{
+    public class OptIntoElmahIoMultipartBodyLoggingMetadata : IOptIntoElmahIoMultipartBodyLoggingMetadata { }
+}


### PR DESCRIPTION
Here are some ideas for Elmah.Io.AspNetCore.ExtensionsLogging:

I improved the Form data logging by making the function async to be able to use `Request.ReadFormAsync` instead of the direct access via `Request.Form`, because that's no longer recommended according to Microsoft's documentation (sync over async).

For the .NET 8.0 target I also added two extension methods:

`DisableElmahIoFormLogging` which can be used in Minimal API to disable form data logging per endpoint (i.e. for privacy or security reasons or because large amounts of data are contained in the form data)

 `OptIntoElmahIoMultipartBodyLogging` which can be used to explicitly allow logging of multipart form data which is normally disabled because it can lead to exceptions. But if the user knows that he's not accessing the body stream or has request buffering enabled anyway, he can opt into this feature.